### PR TITLE
Add Windows build script and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,46 +3,82 @@
 `hwc` is a wrapper around [Hosted Web Core API](https://msdn.microsoft.com/en-us/library/ms693832(v=vs.90).aspx) for running .NET Applications on Windows.
 
 ## Dependencies
-- [Golang Windows](https://golang.org/dl/)
+- [Golang](https://golang.org/dl/)
 - [Ginkgo](https://onsi.github.io/ginkgo/)
-- Install Windows/.NET Features from Powershell by running:
+- [MinGW-w64](https://sourceforge.net/projects/mingw-w64/)
 
-  ```
-  Install-WindowsFeature Web-WHC
-  Install-WindowsFeature Web-Webserver
-  Install-WindowsFeature Web-WebSockets
-  Install-WindowsFeature Web-WHC
-  Install-WindowsFeature Web-ASP
-  Install-WindowsFeature Web-ASP-Net45
+## Compiling on Windows 
 
-  # Not needed when running in Windows 2016
-  Install-WindowsFeature AS-Web-Support
-  Install-WindowsFeature AS-NET-Framework
-  ```
+1. Install Golang from the [golang downloads page](https://golang.org/dl/).
+2. Install MinGW-w64 using the [mingw-w64-install.exe](https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/installer/).
+3. Ensure you've set the GOPATH environment variable.
+4. Ensure you've added the `x86_64-w64-mingw32-gcc` compiler to your Windows PATH.
 
-### Building
+```PowerShell
+git clone git@github.com:cloudfoundry-incubator/hwc "$env:GOPATH/src/code.cloudfoundry.org/hwc"
+cd "$env:GOPATH/src/code.cloudfoundry.org/hwc"
+.\scripts\build.ps1
+```
+
+## Cross Compiling on OSX
+
+1. Install Golang from the [golang downloads page](https://golang.org/dl/).
+2. Install MinGW-w64, `brew install mingw-w64`
+3. Ensure you've set the GOPATH environment variable.
 
 ```
 git clone git@github.com:cloudfoundry-incubator/hwc $GOPATH/src/code.cloudfoundry.org/hwc
 cd $GOPATH/src/code.cloudfoundry.org/hwc
 ./scripts/build.sh
-
 ```
 
-### Test
+## Cross Compiling on Linux
 
-Unit Tests:
+1. Install Golang `sudo apt-get install gccgo-go` 
+2. Install MinGW-w64, `sudo apt-get install mingw-w64`
+3. Ensure you've set the GOPATH environment variable.
 
 ```
-ginkgo -r -race
+git clone git@github.com:cloudfoundry-incubator/hwc $GOPATH/src/code.cloudfoundry.org/hwc
+cd $GOPATH/src/code.cloudfoundry.org/hwc
+./scripts/build.sh
 ```
 
-### Running
+## Running the Tests (Windows Only)
+
+Install Windows/.NET Features from Powershell by running:
+```
+Install-WindowsFeature Web-WHC
+Install-WindowsFeature Web-Webserver
+Install-WindowsFeature Web-WebSockets
+Install-WindowsFeature Web-WHC
+Install-WindowsFeature Web-ASP
+Install-WindowsFeature Web-ASP-Net45
+
+# Not needed when running in Windows 2016
+Install-WindowsFeature AS-Web-Support
+Install-WindowsFeature AS-NET-Framework
+```
+
+Install ginkgo and gomega:
+```
+go get github.com/onsi/ginkgo/ginkgo
+go get github.com/onsi/gomega
+```
+
+Execute the tests:
+```
+& "$env:GOPATH\bin\ginkgo.exe" -r -race
+```
+
+This will run the test suite which spins up several web applications hosted under hwc.exe and validates the behavior.
+
+## Running (Windows Only)
 
 When web applications are pushed to Cloud Foundry they are pushed out to one or more Windows cells and run via `hwc.exe`. For development purposes you can run an ASP.NET web application much like IISExpress by directly invoking `hwc.exe`.
 
-1. Install the following Windows features: Hostable Web Core, ASP.NET 4.6, Websockets.
-1. [Build](https://code.cloudfoundry.org/hwc#building) hwc.exe, or [Download](https://github.com/cloudfoundry-incubator/hwc/releases/) the prebuilt binary from the GitHub releases page.
+1. Install the Windows features in the "Running the Tests" section above.
+1. Build hwc.exe, or [Download](https://github.com/cloudfoundry-incubator/hwc/releases/) the prebuilt binary from the GitHub releases page.
 1. From PowerShell start the web server: `& { $env:PORT=8080; .\hwc.exe -appRootPath "C:\wwwroot\inetpub\myapproot" }`. Ensure the appRootPath points to a directory with a ready to run ASP.NET application.
 
 You should now be able to browse to `http://localhost:8080/` and even attach a debugger and set breakpoints to the `hwc.exe` process if so desired.

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,0 +1,11 @@
+if (-not (Test-Path env:GOPATH)) {
+  Write-Output 'GOPATH environment variable must be set before running build!'
+  exit 1
+}
+
+New-Item -path "$PWD/hwc-rel" -type directory -force
+$env:CGO_ENABLED=1
+$env:GO_EXTLINK_ENABLED=1
+$env:CC="x86_64-w64-mingw32-gcc"
+
+go build -o $PWD/hwc-rel/hwc.exe code.cloudfoundry.org/hwc


### PR DESCRIPTION
This adds a PowerShell script for building hwc.exe from Windows along with instructions on how to execute the tests on Windows. The readme also contains platform specific instructions for cross compiling to Windows from OSX and Linux.