### PR TITLE
Add DISM installation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,16 +48,10 @@ cd $GOPATH/src/code.cloudfoundry.org/hwc
 
 Install Windows/.NET Features from Powershell by running:
 ```
-Install-WindowsFeature Web-WHC
-Install-WindowsFeature Web-Webserver
-Install-WindowsFeature Web-WebSockets
-Install-WindowsFeature Web-WHC
-Install-WindowsFeature Web-ASP
-Install-WindowsFeature Web-ASP-Net45
-
-# Not needed when running in Windows 2016
-Install-WindowsFeature AS-Web-Support
-Install-WindowsFeature AS-NET-Framework
+Enable-WindowsOptionalFeature -Online -All -FeatureName IIS-WebServer
+Enable-WindowsOptionalFeature -Online -All -FeatureName IIS-WebSockets
+Enable-WindowsOptionalFeature -Online -All -FeatureName IIS-HostableWebCore
+Enable-WindowsOptionalFeature -Online -All -FeatureName IIS-ASPNET45
 ```
 
 Install ginkgo:


### PR DESCRIPTION
This updates the feature installation instructions so they work on Windows 10, not just Windows Server 2012/2016.

Using the DISM provider for installing Windows features works across most Windows versions and editions. The old way of installing features would only work on Windows Server editions.