### PR TITLE
Add unique ironfoundry site name and id

### DIFF
--- a/hwcconfig/application_host_config.go
+++ b/hwcconfig/application_host_config.go
@@ -195,7 +195,7 @@ const applicationHostConfigTemplate = `<?xml version="1.0" encoding="UTF-8"?>
       </siteDefaults>
       <applicationDefaults applicationPool="AppPool{{.Config.Port}}" />
       <virtualDirectoryDefaults allowSubDirConfig="true" />
-			<site name="IronFoundrySite" id="1" serverAutoStart="true">
+      <site name="IronFoundrySite{{.Config.Port}}" id="{{.Config.Port}}" serverAutoStart="true">
         <application path="/" applicationPool="AppPool{{.Config.Port}}">
           <virtualDirectory path="/" physicalPath="{{.Config.RootPath}}" />
         </application>


### PR DESCRIPTION
https://github.com/cloudfoundry/wats/issues/21

The ASP.NET compilation lock creates a global system (2012R2 cell level) named mutex based off the application's AppDomainAppId which is the same between instances. This change ensures that within the context of a cell that all application's have a unique site name and id, thus ensuring a unique compilation mutex is created.

This should do two things:
1. Improve cf push performance to Windows cells by parallelizing ASP.NET compilation locks when multiple app instances are starting on a cell.
2. Address wats issue #21 by ensuring app compilations don't interfere with one another.

## Test Procedure
To test this I created two identical ASP.NET apps running from different directories on different ports. One of them I set the PORT env var and the other I set the PORT, TMP, TEMP, and USERPROFILE env vars so they wrote their applicationHost.config out to separate directories.

### Before this PR
![screen shot 2018-01-16 at 7 17 57 pm](https://user-images.githubusercontent.com/197023/35024520-c1ebe912-faf4-11e7-99d9-54bdccd614c7.png)

### After this PR
![screen shot 2018-01-16 at 7 22 04 pm](https://user-images.githubusercontent.com/197023/35024523-c91f6aa6-faf4-11e7-8d3e-c3b9dfb57ed6.png)

Notice the global mutex names are different. To grab the mutex names I used this code:
```c#
            var clAssembly = Assembly.GetAssembly(typeof(BuildManager));
            var clLockType = clAssembly.GetType("System.Web.Compilation.CompilationLock");
            var cmField = clLockType.GetField("_mutex", BindingFlags.Static | BindingFlags.NonPublic);
            var cm = cmField.GetValue(null);
            var cmType = cm.GetType();

            var mdnProp = cmType.GetProperty("MutexDebugName", BindingFlags.NonPublic | BindingFlags.Instance);
            var mdn = mdnProp.GetValue(cm);

            var lsField = cmType.GetField("_lockStatus", BindingFlags.Instance | BindingFlags.NonPublic);
            var ls = lsField.GetValue(cm);

            string appid = Thread.GetDomain().GetData(".appId") as string;

            ViewBag.Message = $"Mutex Name: {mdn}, Lock Status: {ls}, appid: {appid}";
```